### PR TITLE
Clarify greenkeeper is a service not a bundler

### DIFF
--- a/_posts/2018-06-25-vision-for-rust-and-wasm.md
+++ b/_posts/2018-06-25-vision-for-rust-and-wasm.md
@@ -156,7 +156,7 @@ publishing Rust-generated WebAssembly that you would like to interoperate with
 JavaScript, in the browser, or with Node.js.][wasm-pack] `wasm-pack` helps you
 build and publish Rust-generated WebAssembly to the npm registry to be used
 alongside any other JavaScript package in workflows that you already use, such
-as a bundler like [webpack][] or [greenkeeper][].
+as a bundler like [webpack][] or a service like [greenkeeper][].
 
 [![wasm-pack cartoon](/images/wasm-pack-cartoon.png)](/images/wasm-pack-cartoon.png)
 


### PR DESCRIPTION
Someone on Twitter had mentioned that greenkeeper was not a bundler. Given the wording of the sentence this made it not clear even though it was meant to work with the workflows people would use as indicated in the previous sentence. This makes the distinction more clear.