### PR TITLE
[WIP] Rust and WebAssembly in 2019: A Call for Community Blog Posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site
 .sass-cache
 .jekyll-metadata
+.bundle
+vendor

--- a/_config.yml
+++ b/_config.yml
@@ -32,10 +32,10 @@ plugins:
 # to override the default setting.
 exclude:
   - template.md
+  - vendor/bundle/
 #   - Gemfile
 #   - Gemfile.lock
 #   - node_modules
-#   - vendor/bundle/
 #   - vendor/cache/
 #   - vendor/gems/
 #   - vendor/ruby/

--- a/_posts/2018-12-06-rust-and-wasm-in-2019-a-call-for-blog-posts.md
+++ b/_posts/2018-12-06-rust-and-wasm-in-2019-a-call-for-blog-posts.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: "Rust and WebAssembly in 2019: A Call for Community Blog Posts"
+---
+
+[The 2018 edition of Rust has officially shipped! 🎉][rust-2018]
+
+The Rust and WebAssembly domain working group's goals have historically been
+focused on things we can deliver in tandem for the 2018 edition. Now that the
+2018 edition has shipped, it is time to think about what we want to achieve in
+2019 and beyond.
+
+Following in the larger Rust project's [tradition][rust-2019-call-for-blogs],
+we're asking the community to write blog posts reflecting on Rust and
+WebAssembly in 2018 and proposing goals and directions for Rust and WebAssembly
+in 2019. We'll read everything, and then propose an [RFC][rust-wasm-rfcs] for
+the Rust and WebAssembly domain working group's roadmap in 2019.
+
+## #RustWasm2019
+
+Write down your thoughts on whatever your writing platform of choice is. It
+could be:
+
+* Your personal or company blog
+* A GitHub gist
+* A Medium post
+* Any other platform you prefer
+
+We're looking for posts on many different topics:
+
+* Ideas for community programs
+* Tooling enhancements
+* Ecosystem and library needs
+* Documentation improvements
+* Anything else related to Rust and Wasm!
+
+Tweet your write up with [the `#RustWasm2019` hashtag][hashtag] or drop a link
+on [this github issue][rust-wasm-2019-issue]. We'll aggregate everything
+everyone has written in another big post on this blog. Then, the core Rust and
+WebAssembly working group team will read over all of them and write up an RFC
+for the working group's 2019 roadmap! This RFC will follow our normal [RFC
+process][] and everyone will have a chance to discuss it, improve it, and help
+polish it.
+
+## Preliminary Timeline
+
+* **Now through January 15<sup>th</sup>:** Share your `#RustWasm2019` post, read
+  posts by others, discuss them, bounce ideas back and forth.
+* **End of January:** We'll formally propose the 2019 roadmap RFC, and then work
+  it through the RFC process together as a community.
+* **End of February:** We're aiming for having consensus on the 2019 roadmap and
+  merging the RFC before the end of February.
+
+## Thanks for an Awesome 2018!
+
+Thanks to everyone who generated some WebAssembly with Rust in 2018 and thanks
+to everyone who helped make that possible!
+
+[rust-2018]: TODO
+[rust-2019-call-for-blogs]: TODO https://github.com/rust-lang/blog.rust-lang.org/pull/292
+[rust-wasm-rfcs]: https://github.com/rustwasm/rfcs
+[hashtag]: https://twitter.com/search?q=%23RustWasm2019
+[rust-wasm-2019-issue]: TODO
+[RFC process]: https://rustwasm.github.io/rfcs/001-the-rfc-process.html


### PR DESCRIPTION
Hoping to publish this on December 6th, alongside the Rust 2018 edition release (woo!!) and https://github.com/rust-lang/blog.rust-lang.org/pull/292