### PR TITLE
Fix dead link to host bindings proposal overview

### DIFF
--- a/_posts/2019-03-26-gloo-onion-layers.md
+++ b/_posts/2019-03-26-gloo-onion-layers.md
@@ -282,7 +282,7 @@ Let's build Gloo together! Want to get involved?
 [Gloo]: https://github.com/rustwasm/gloo
 [set-timeout]: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout
 [announcing-web-sys]: https://rustwasm.github.io/2018/09/26/announcing-web-sys.html
-[host-bindings]: https://github.com/WebAssembly/host-bindings/blob/master/proposals/host-bindings/Overview.md
+[host-bindings]: https://github.com/WebAssembly/webidl-bindings/blob/9ada880991a26081279ee6b74e26502f5046a010/proposals/host-bindings/Overview.md
 [state-machine-future]: https://github.com/fitzgen/state_machine_future
 [integrate-futures-signals]: https://github.com/rustwasm/gloo/issues/33
 [dominator]: https://github.com/Pauan/rust-dominator


### PR DESCRIPTION
The [latest commit](https://github.com/WebAssembly/webidl-bindings/commit/e52ecda6d7ec90a0b0aceb5e8577151b9798389c) seems to have invalidated the link. It also seems like the repository was renamed? At least I get re-rerouted to the webidl-bindings repo when clicking on [the link](https://github.com/WebAssembly/host-bindings/blob/master/proposals/host-bindings/Overview.md) from the blog post.

Please tell me if there are any guidelines that I have missed or feel free to correct the link, if this is the wrong document.

