### PR TITLE
Blog: Fix mistake in code example

### DIFF
--- a/_posts/2019-03-26-gloo-onion-layers.md
+++ b/_posts/2019-03-26-gloo-onion-layers.md
@@ -63,7 +63,7 @@ let js_val = closure.as_ref();
 let js_func = js_val.unchecked_ref::<js_sys::Function>();
 
 // Finally, call the `window.setTimeout` API.
-let id = web_sys::window()
+let timeout_id = web_sys::window()
     .expect("should have a `window`")
     .set_timeout_with_callback_and_timeout_and_arguments_0(js_func, 500)
     .expect("should set a timeout OK");


### PR DESCRIPTION
Simple change. The variable is used with the proposed name [a few lines below](https://github.com/rustwasm/rustwasm.github.io/compare/src...timotree3:patch-1#diff-e7d0fb2c7c10bfa0e6470eadfc9cd416L74)